### PR TITLE
Make homepage less resume-like, update title to Staff SWE

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ url: "https://shahrajat.github.io"
 baseurl: ""
 
 title: Rajat Shah
-description: Senior Software Engineer building ML infrastructure at scale
+description: Staff Software Engineer building ML infrastructure at scale
 
 # --- Navigation --- #
 

--- a/aboutme.html
+++ b/aboutme.html
@@ -8,7 +8,7 @@ published: true
 <div class="about-content">
 
 <p>
-I'm a Senior Software Engineer at Netflix, where I build the core Model Inference Platform &mdash; the infrastructure that serves ML predictions at scale across recommendations, search, ads, and personalization for 200M+ subscribers worldwide.
+I'm a Staff Software Engineer at Netflix, where I build the core Model Inference Platform &mdash; the infrastructure that serves ML predictions at scale across recommendations, search, ads, and personalization for 200M+ subscribers worldwide.
 </p>
 
 <p>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,13 @@ title: Rajat Shah
   <div class="hero">
     <h1>Rajat Shah</h1>
     <p class="lead">
-      Senior Software Engineer at Netflix, building the core Model Inference Platform
-      that serves large-scale ML predictions across all Netflix products.
-      Previously built distributed systems at Amazon, Morgan Stanley, and Goldman Sachs.
+      I'm a Staff Software Engineer at Netflix, where I build the
+      Model Inference Platform &mdash; the infrastructure behind ML predictions
+      that power recommendations, search, and personalization for 200M+ subscribers.
+    </p>
+    <p class="lead">
+      I like building things that work at scale, and occasionally
+      <a href="/writing">writing</a> about what I learn along the way.
     </p>
     <div class="hero-links">
       <a href="https://github.com/{{ site.author.github }}" target="_blank" rel="noopener">
@@ -32,80 +36,22 @@ title: Rajat Shah
   </div>
 
   <div class="section">
-    <h2 class="section-title">Experience</h2>
-    <ul class="timeline">
-      <li class="timeline-item">
-        <span class="timeline-date">2021 &mdash; Present</span>
-        <div class="timeline-content">
-          <h3>Netflix</h3>
-          <p class="role">Senior Software Engineer, Model Inference Platform</p>
-          <p>Building the core inference infrastructure that serves ML predictions at enormous scale across all Netflix products &mdash; recommendations, search, ads, and more.</p>
-        </div>
-      </li>
-      <li class="timeline-item">
-        <span class="timeline-date">2017 &mdash; 2021</span>
-        <div class="timeline-content">
-          <h3>Amazon</h3>
-          <p class="role">Software Development Engineer</p>
-          <p>Built large-scale distributed systems. Created Amazon Gather, a virtual events platform, as a side project that earned the <strong>Just Do It Award from Jeff Bezos</strong> &mdash; one of Amazon's most prestigious internal honors.</p>
-        </div>
-      </li>
-      <li class="timeline-item">
-        <span class="timeline-date">2016 &mdash; 2017</span>
-        <div class="timeline-content">
-          <h3>Morgan Stanley</h3>
-          <p class="role">Software Engineer</p>
-          <p>Worked on large-scale distributed systems in the Institutional Securities Technology division.</p>
-        </div>
-      </li>
-      <li class="timeline-item">
-        <span class="timeline-date">2015</span>
-        <div class="timeline-content">
-          <h3>Goldman Sachs</h3>
-          <p class="role">Summer Analyst (Intern)</p>
-          <p>Engineering internship in the Securities division.</p>
-        </div>
-      </li>
-    </ul>
-  </div>
-
-  <div class="section">
-    <h2 class="section-title">Education</h2>
-    <ul class="timeline">
-      <li class="timeline-item">
-        <span class="timeline-date">2015 &mdash; 2016</span>
-        <div class="timeline-content">
-          <h3>North Carolina State University</h3>
-          <p>M.S. Computer Science &mdash; Machine Learning, NLP, AI</p>
-        </div>
-      </li>
-      <li class="timeline-item">
-        <span class="timeline-date">2011 &mdash; 2015</span>
-        <div class="timeline-content">
-          <h3>VNIT, India</h3>
-          <p>B.Tech. Computer Science &amp; Engineering</p>
-        </div>
-      </li>
-    </ul>
-  </div>
-
-  <div class="section">
-    <h2 class="section-title">Selected Work</h2>
+    <h2 class="section-title">Things I've worked on</h2>
     <div class="card-grid">
       <a href="/work" class="card" style="text-decoration: none; color: inherit;">
         <h3>ML Inference at Netflix Scale</h3>
-        <p>Core platform powering real-time model predictions across recommendations, search, and ads for 200M+ subscribers.</p>
+        <p>The platform behind real-time model predictions across recommendations, search, and ads for 200M+ subscribers.</p>
         <span class="meta">Infrastructure &middot; ML Systems &middot; Distributed Computing</span>
       </a>
       <a href="/work" class="card" style="text-decoration: none; color: inherit;">
-        <h3>Amazon Gather &amp; Just Do It Award</h3>
-        <p>Built a virtual events and networking platform at Amazon. Recognized with the Just Do It Award by Jeff Bezos.</p>
-        <span class="meta">Full-Stack &middot; Side Project &middot; Leadership</span>
+        <h3>Amazon Gather</h3>
+        <p>A virtual events and networking platform I built as a pandemic side project at Amazon. Earned the Just Do It Award from Jeff Bezos.</p>
+        <span class="meta">Full-Stack &middot; Side Project</span>
       </a>
       <a href="/research" class="card" style="text-decoration: none; color: inherit;">
-        <h3>Research Publications</h3>
-        <p>Published work in Educational Data Mining and IEEE on deep learning for automated grading and screenshot analysis.</p>
-        <span class="meta">Deep Learning &middot; NLP &middot; EDM &middot; IEEE</span>
+        <h3>Research &amp; Publications</h3>
+        <p>Published work on deep learning for automated grading (EDM) and screenshot analysis (IEEE) during grad school at NC State.</p>
+        <span class="meta">Deep Learning &middot; NLP &middot; Computer Vision</span>
       </a>
     </div>
   </div>

--- a/work.md
+++ b/work.md
@@ -7,7 +7,7 @@ published: true
 
 <div class="work-entry">
   <h3>Netflix &mdash; Model Inference Platform</h3>
-  <p class="work-meta">Senior Software Engineer &middot; 2021 &ndash; Present</p>
+  <p class="work-meta">Staff Software Engineer &middot; 2021 &ndash; Present</p>
   <ul>
     <li>Building the core Model Inference Platform that serves large-scale ML predictions across all Netflix products &mdash; powering recommendations, search, ads, and personalization for 200M+ subscribers.</li>
     <li>Designing and operating inference infrastructure that handles massive throughput with strict latency requirements, balancing cost efficiency with reliability.</li>


### PR DESCRIPTION
- Remove Experience/Education timeline from homepage, keep it conversational with hero + selected work cards
- Move detailed work history to /work page only
- Update Netflix title from Senior to Staff Software Engineer across all pages and config